### PR TITLE
Added in try catching for MQTT publish call

### DIFF
--- a/code/labBasicPubSub.py
+++ b/code/labBasicPubSub.py
@@ -119,8 +119,13 @@ while True:
         message['message'] = random.randint(1,100)
         message['sequence'] = loopCount
         messageJson = json.dumps(message)
-        myAWSIoTMQTTClient.publish(topic, messageJson, 1)
-        if args.mode == 'publish':
-            print('Published topic %s: %s\n' % (topic, messageJson))
+        try:
+            myAWSIoTMQTTClient.publish(topic, messageJson, 1)
+        except Exception as e:
+            print(e)
+            print("Had an exception on publish.")
+        else:
+            if args.mode == 'publish':
+                print('Published topic %s: %s\n' % (topic, messageJson))
         loopCount += 1
     time.sleep(1)


### PR DESCRIPTION
Without this, there may be exception like this and halting the script.
```
Traceback (most recent call last):
  File "/home/ec2-user/environment/aws-iot-core-workshop/code/labBasicPubSub.py", line 122, in <module>
    myAWSIoTMQTTClient.publish(topic, messageJson, 1)
  File "/home/ec2-user/.local/lib/python3.9/site-packages/AWSIoTPythonSDK/MQTTLib.py", line 628, in publish
    return self._mqtt_core.publish(topic, payload, QoS, False)  # Disable retain for publish by now
  File "/home/ec2-user/.local/lib/python3.9/site-packages/AWSIoTPythonSDK/core/protocol/mqtt_core.py", line 273, in publish
    raise publishTimeoutException()
AWSIoTPythonSDK.exception.AWSIoTExceptions.publishTimeoutException
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
